### PR TITLE
add retry

### DIFF
--- a/codefresh/deploy.yaml
+++ b/codefresh/deploy.yaml
@@ -19,6 +19,17 @@ steps:
     type: pending-approval
     title: Deploy release?
 
+  wait:
+    title: Wait
+    stage: Prepare
+    image: codefresh/cli:latest
+    commands:
+      - codefresh get builds --pipeline=deploy --status running --limit 1000 -o json | jq --arg id ${{CF_BUILD_ID}} -ser 'flatten|.[-1].id==$id'
+    retry:
+      maxAttempts: 10
+      delay: 20
+      exponentialFactor: 1.1
+
   deploy_helmfile:
     title: "Deploy with helmfile"
     stage: "Deploy"

--- a/codefresh/release.yaml
+++ b/codefresh/release.yaml
@@ -19,9 +19,9 @@ steps:
     stage: "Promote"
     image: "${{CF_DOCKER_REPO_URL}}/${{CF_REPO_NAME}}:${{CF_REVISION}}"
     retry:
-      maxAttempts: 40
-      delay: 15
-      exponentialFactor: 1
+      maxAttempts: 10
+      delay: 20
+      exponentialFactor: 1.1
     commands:
     - "true"
 

--- a/codefresh/release.yaml
+++ b/codefresh/release.yaml
@@ -18,6 +18,10 @@ steps:
     title: Pull image with commit sha
     stage: "Promote"
     image: "${{CF_DOCKER_REPO_URL}}/${{CF_REPO_NAME}}:${{CF_REVISION}}"
+    retry:
+      maxAttempts: 40
+      delay: 15
+      exponentialFactor: 1
     commands:
     - "true"
 

--- a/deploy/releases/app.yaml
+++ b/deploy/releases/app.yaml
@@ -86,7 +86,6 @@ releases:
           timeoutSeconds: 3
           successThreshold: 1
           failureThreshold: 2
-          scheme: HTTP
         
         # Probe that ensures service has started
         readinessProbe:


### PR DESCRIPTION
## what
* Add retry for releases
* Add wait for deploy
* Fixed schema validation

## why
* If you merge and cut a release immediately thereafter, the release will fail
* The retry ensures release is cut as soon as image is built
* The wait step ensures we don't have concurrent helm deployments 